### PR TITLE
fix: userId 기반 모델 응답 라우팅 및 per-user 시퀀스 분리

### DIFF
--- a/src/controllers/streamController.js
+++ b/src/controllers/streamController.js
@@ -25,8 +25,8 @@ class StreamController {
         }
 
         try {
-            const serverUrl = 'wss://streaming.trout-stream.n-e.kr/stream?userId=${this.userId}';
-            // const serverUrl = `ws://localhost:3000/stream?userId=${this.userId}`;
+            // const serverUrl = `wss://streaming.trout-stream.n-e.kr/stream?userId=${this.userId}`;
+            const serverUrl = `ws://localhost:3000/stream?userId=${this.userId}`;
             console.log("@#@# serverURL:",serverUrl);
             this.streamingServer = new WebSocket(serverUrl);
             this.streamingServer.binaryType = 'arraybuffer';
@@ -115,20 +115,16 @@ class StreamController {
         }
         
         try {
-            const { canvas, stream } = this.prepareVideoStream(video);
-            const { chosenMimeType, videoBitsPerSecond, recorderOptions } = this.getRecorderOptions();
-            const { recorder, drawFrameId } = this.startRecorderAndDrawing(video, canvas, stream, recorderOptions, userId, chosenMimeType);
+            const { canvas } = this.prepareVideoStream(video);
+            const intervalId = this.startFrameSending(video, canvas, userId);
 
             this.streamingUsers.set(userId, {
-                stream,
                 canvas,
-                ctx: canvas.getContext('2d'),
                 video,
-                recorder,
-                drawFrameId,
+                intervalId,
             });
 
-            this.notifyServerOfStart(userId, user.name, canvas.width, canvas.height, chosenMimeType, videoBitsPerSecond);
+            this.notifyServerOfStart(userId, user.name, canvas.width, canvas.height);
         } catch (error) {
             console.error(`Error starting stream for user ${userId}:`, error);
         }
@@ -136,49 +132,24 @@ class StreamController {
 
     prepareVideoStream(video) {
         const canvas = document.createElement('canvas');
-        const ctx = canvas.getContext('2d');
-        
+
         const sourceWidth = video.videoWidth;
         const sourceHeight = video.videoHeight;
         const targetMaxWidth = 640;
         const scale = Math.min(1, targetMaxWidth / (sourceWidth || 1));
         const targetWidth = Math.max(1, Math.round((sourceWidth || 1) * scale));
         const targetHeight = Math.max(1, Math.round((sourceHeight || 1) * scale));
-        
+
         canvas.width = targetWidth;
         canvas.height = targetHeight;
-        
-        const stream = canvas.captureStream(30);
-        console.log("@#@# video is ready (canvas, stream) : ",!!canvas, !!stream);
-        return { canvas, stream };
+
+        return { canvas };
     }
 
-    getRecorderOptions() {
-        const preferredMimeTypes = [
-            'video/webm;codecs=vp9',
-            'video/webm;codecs=vp8',
-            'video/webm',
-        ];
-        const chosenMimeType = preferredMimeTypes.find((t) => {
-            try {
-                return window.MediaRecorder && MediaRecorder.isTypeSupported(t);
-            } catch (_) {
-                return false;
-            }
-        }) || 'video/webm';
-
-        const videoBitsPerSecond = 800000;
-        const recorderOptions = {
-            mimeType: chosenMimeType,
-            videoBitsPerSecond,
-        };
-        
-        return { chosenMimeType, videoBitsPerSecond, recorderOptions };
-    }
-
-    startRecorderAndDrawing(video, canvas, stream, recorderOptions, userId, chosenMimeType) {
+    startFrameSending(video, canvas, userId) {
         const ctx = canvas.getContext('2d');
-        const draw = () => {
+        const intervalId = setInterval(() => {
+            if (!this.streamingServer || this.streamingServer.readyState !== WebSocket.OPEN) return;
             try {
                 if (video.videoWidth > 0 && video.videoHeight > 0) {
                     ctx.save();
@@ -186,46 +157,22 @@ class StreamController {
                     ctx.drawImage(video, -canvas.width, 0, canvas.width, canvas.height);
                     ctx.restore();
                 }
+                canvas.toBlob((blob) => {
+                    if (!blob || !this.streamingServer || this.streamingServer.readyState !== WebSocket.OPEN) return;
+                    blob.arrayBuffer().then(buffer => {
+                        if (this.streamingServer && this.streamingServer.readyState === WebSocket.OPEN) {
+                            this.streamingServer.send(buffer);
+                        }
+                    });
+                }, 'image/jpeg', 0.7);
             } catch (e) {
-                console.warn(`Draw error for user ${userId}:`, e);
-            } finally {
-                const streamData = this.streamingUsers.get(userId);
-                streamData.drawFrameId = requestAnimationFrame(draw);
+                console.warn(`Frame capture error for user ${userId}:`, e);
             }
-        };
-        const drawFrameId = requestAnimationFrame(draw);
-        const recorder = new MediaRecorder(stream, recorderOptions);
-        
-        recorder.ondataavailable = (event) => {
-            if (!event.data || event.data.size == null || event.data.size === 0) {
-                console.warn(`Skipping empty chunk for user ${userId}`);
-                return;
-            }
-            if (!this.streamingServer || this.streamingServer.readyState !== WebSocket.OPEN) {
-                return;
-            }
-            
-            // this.streamingServer.send(JSON.stringify({
-            //     type: 'video_chunk',
-            //     userId,
-            //     timestamp: Date.now(),
-            //     size: event.data.size,
-            //     mimeType: recorder.mimeType || chosenMimeType || 'video/webm',
-            // }));
-            console.log("@#@# 데이터를 보냄 : ",!!event.data);
-            this.streamingServer.send(event.data);
-        };
-
-        recorder.onerror = (err) => console.error(`MediaRecorder error for user ${userId}:`, err);
-        recorder.onstart = () => console.log(`MediaRecorder started for user ${userId}`);
-        recorder.onstop = () => console.log(`MediaRecorder stopped for user ${userId}`);
-        
-        recorder.start(1000); // Emit chunks every 1000ms
-        
-        return { recorder, drawFrameId };
+        }, 100); // ~10fps
+        return intervalId;
     }
 
-    notifyServerOfStart(userId, userName, width, height, mimeType, videoBitsPerSecond) {
+    notifyServerOfStart(userId, userName, width, height) {
         if (this.streamingServer && this.streamingServer.readyState === WebSocket.OPEN) {
             this.streamingServer.send(JSON.stringify({
                 type: 'start_stream',
@@ -233,11 +180,10 @@ class StreamController {
                 userName: userName || userId,
                 width,
                 height,
-                fps: 30,
-                mimeType: mimeType || undefined,
-                videoBitsPerSecond,
+                fps: 10,
+                mimeType: 'image/jpeg',
             }));
-            console.log(`Started streaming user ${userId} with MediaRecorder (${mimeType}) at ${videoBitsPerSecond}bps`);
+            console.log(`Started streaming user ${userId} with JPEG frames at 10fps`);
         }
     }
 
@@ -266,21 +212,8 @@ class StreamController {
             return;
         }
 
-        if (streamData.drawFrameId) {
-            cancelAnimationFrame(streamData.drawFrameId);
-            streamData.drawFrameId = null;
-        }
-
-        if (streamData.recorder && streamData.recorder.state !== 'inactive') {
-            try {
-                streamData.recorder.stop();
-            } catch (_) {
-
-            }
-        }
-
-        if (streamData.stream) {
-            streamData.stream.getTracks().forEach(track => track.stop());
+        if (streamData.intervalId) {
+            clearInterval(streamData.intervalId);
         }
 
         if (this.streamingServer && this.streamingServer.readyState === WebSocket.OPEN) {

--- a/src/controllers/streamController.js
+++ b/src/controllers/streamController.js
@@ -25,8 +25,8 @@ class StreamController {
         }
 
         try {
-            // const serverUrl = `wss://streaming.trout-stream.n-e.kr/stream?userId=${this.userId}`;
-            const serverUrl = `ws://localhost:3000/stream?userId=${this.userId}`;
+            const serverUrl = `wss://streaming.trout-stream.n-e.kr/stream?userId=${this.userId}`;
+            //const serverUrl = `ws://localhost:3000/stream?userId=${this.userId}`;
             console.log("@#@# serverURL:",serverUrl);
             this.streamingServer = new WebSocket(serverUrl);
             this.streamingServer.binaryType = 'arraybuffer';


### PR DESCRIPTION
### Issue
#15 

### 변경 사항 요약
- 바이너리 프레임에 4바이트 userId 헤더를 추가해 모델이 사용자별 시퀀스를 분리 유지
- 모델 응답에 userId를 포함시키고, 스트리밍 서버가 해당 사용자 클라이언트에만 전달
- Chrome Extension의 WebSocket URL 템플릿 리터럴 버그 수정

### 변경 파일
- `streaming-server/src/controllers/webSocketController.js`
- `streaming-server/src/controllers/modelController.js`
- `sign-language-korean/main.py`
- `chrome-extension/src/controllers/streamController.js`

### 상세 내용

#### 바이너리 프레임 프로토콜 (신규)
[ 4 bytes: userId length (uint32 big-endian) ]
[ N bytes: userId (UTF-8) ]
[ remaining: JPEG frame data ]

#### webSocketController.js
- binary 수신 시 4바이트 userId 헤더 + userId bytes를 프레임 앞에 prepend
- `stop_stream` 처리 시 모델 서버에도 `{type: 'stop_stream', userId}` 전송
  (모델이 해당 userId의 deque/holistic 정리 가능)

#### modelController.js
- `wss.clients.forEach` broadcast → `client.userId === targetUserId` 조건부 전달
- 모델 응답의 `userId` 필드를 사용해 특정 클라이언트에만 라우팅

#### main.py
- `import json` 추가
- 단일 `sequence_data` deque → `user_sequences: dict[str, deque]`로 교체
- 단일 `holistic` → `user_holistics: dict[str, Holistic]`로 교체
- `await websocket.receive()` 로 텍스트(JSON 제어 메시지)와 바이너리 통합 처리
- `stream_config`: userId별 deque + Holistic 초기화
- `stop_stream`: 해당 userId 리소스 즉시 해제
- binary: 헤더에서 userId 파싱 → per-userId deque에 프레임 추가 → 예측
- 응답: `{"userId": user_id, "text": result_text}`
- lazy 초기화: stream_config 없이 프레임 도착 시에도 자동 초기화
- finally: 연결 종료 시 모든 userId Holistic 리소스 정리

#### streamController.js (bonus)
- `'wss://...?userId=${this.userId}'` (single quote) → `` `wss://...?userId=${this.userId}` `` (backtick)
  으로 수정하여 userId가 실제로 URL에 삽입되도록 수정

### 테스트 방법
1. 2명의 Google Meet 참가자 선택 후 해석 시작
2. 모델 서버 로그에서 `[user_1] 시퀀스 및 MediaPipe 초기화`, `[user_2] 시퀀스 및 MediaPipe 초기화` 확인
3. 스트리밍 서버 로그에서 `Model server response (userId: user_1)` 형태 확인
4. 각 참가자의 번역 결과가 해당 Chrome Extension에만 전달되는지 확인

### 한계 (향후 개선 사항)
현재 Chrome Extension은 모든 참가자 영상을 하나의 WebSocket 연결로 전송한다.
완전한 다중 사용자 지원을 위해서는 참가자별 별도 WebSocket 연결이 필요하다.